### PR TITLE
Validation Schema + Refactor bug fixes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
 		"build:binaries": "run-s build bin",
 		"start": "node ./dist/src/index.js",
 		"format": "prettier --write .",
+		"test": "vitest --",
 		"start:fresh": "npm-run-all -s build start",
 		"ts": "tsc --noEmit",
 		"lint": "eslint -c ./.eslintrc ./src/**/*.ts"
@@ -33,6 +34,7 @@
 		"@inquirer/prompts": "^3.3.0",
 		"@logsn/client": "workspace:*",
 		"@logsn/shared": "workspace:*",
+		"streamr-client": "^8.5.5",
 		"chalk": "^4.1.2",
 		"commander": "^11.0.0",
 		"decimal.js": "^10.4.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@logsn/cli",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"author": "Ryan Soury <ryan@usher.so>",
 	"license": "GPL-3.0",
 	"description": "The Log Store Network CLI",

--- a/packages/cli/src/commands/balance.ts
+++ b/packages/cli/src/commands/balance.ts
@@ -1,5 +1,5 @@
 import { readFeeMultiplier } from '@/configuration';
-import { getLogStoreClientFromOptions } from '@/utils/logstore-client';
+import { getClientsFromOptions } from '@/utils/logstore-client';
 import { bytesToMessage, logger } from '@/utils/utils';
 import { Command } from '@commander-js/extra-typings';
 import chalk, { bold } from 'chalk';
@@ -17,9 +17,11 @@ export const balanceCommand = new Command()
 	)
 	.action(async (cmdOptions) => {
 		try {
-			const client = getLogStoreClientFromOptions();
-			const balanceInLSAN = new Decimal((await client.getBalance()).toString());
-			const price = new Decimal((await client.getPrice()).toString());
+			const { logStoreClient } = getClientsFromOptions();
+			const balanceInLSAN = new Decimal(
+				(await logStoreClient.getBalance()).toString()
+			);
+			const price = new Decimal((await logStoreClient.getPrice()).toString());
 
 			// TODO review this when multiplier from contract != 1
 			const availableStorage = balanceInLSAN;
@@ -29,7 +31,7 @@ export const balanceCommand = new Command()
 
 			console.log(
 				`The LSAN balance for address ${bold(
-					await client.getAddress()
+					await logStoreClient.getSigner().then((s) => s.getAddress())
 				)} is ${bold(balanceInLSAN.toString())}.`
 			);
 			console.log(

--- a/packages/cli/src/commands/create-stream.ts
+++ b/packages/cli/src/commands/create-stream.ts
@@ -1,4 +1,4 @@
-import { getLogStoreClientFromOptions } from '@/utils/logstore-client';
+import { getClientsFromOptions } from '@/utils/logstore-client';
 import { Command } from '@commander-js/extra-typings';
 
 export const createStreamCommand = new Command()
@@ -10,9 +10,9 @@ export const createStreamCommand = new Command()
 	.action(async (name: string) => {
 		// const provider = new ethers.providers.JsonRpcProvider(rootOptions.host);
 		// const signer = new ethers.Wallet(rootOptions.wallet, provider);
-		const client = getLogStoreClientFromOptions();
+		const { streamrClient } = getClientsFromOptions();
 		console.log('Creating a stream...');
-		const stream = await client.createStream({
+		const stream = await streamrClient.createStream({
 			// id: name.charAt(0) === '/' ? name : `/${name}`,
 			id: name,
 		});

--- a/packages/cli/src/commands/mint.ts
+++ b/packages/cli/src/commands/mint.ts
@@ -1,8 +1,8 @@
 import { getRootOptions } from '@/commands/options';
 import { fastPriorityIfMainNet$ } from '@/utils/gasStation';
 import {
+	getClientsFromOptions,
 	getCredentialsFromOptions,
-	getLogStoreClientFromOptions,
 } from '@/utils/logstore-client';
 import { keepRetryingWithIncreasedGasPrice } from '@/utils/speedupTx';
 import {
@@ -43,7 +43,7 @@ export const mintCommand = new Command()
 		const { signer, provider } = getCredentialsFromOptions();
 
 		try {
-			const client = getLogStoreClientFromOptions();
+			const { logStoreClient } = getClientsFromOptions();
 
 			const mintType = cmdOptions.usd
 				? 'usd'
@@ -53,14 +53,14 @@ export const mintCommand = new Command()
 
 			await printPrices();
 
-			const amountInToken = await client.convert({
+			const amountInToken = await logStoreClient.convert({
 				amount,
 				from: mintType,
 				to: 'wei',
 			});
 
 			console.log(`Minting ${amountInToken} wei...`);
-			const result = await client.mint(
+			const result = await logStoreClient.mint(
 				BigInt(new Decimal(amountInToken).toHex()),
 				{
 					maxPriorityFeePerGas: await firstValueFrom(fastPriorityIfMainNet$),

--- a/packages/cli/src/commands/query/query-balance.ts
+++ b/packages/cli/src/commands/query/query-balance.ts
@@ -1,5 +1,5 @@
 import { readFeeMultiplier } from '@/configuration';
-import { getLogStoreClientFromOptions } from '@/utils/logstore-client';
+import { getClientsFromOptions } from '@/utils/logstore-client';
 import { bytesToMessage, logger } from '@/utils/utils';
 import { Command } from '@commander-js/extra-typings';
 import chalk from 'chalk';
@@ -10,10 +10,10 @@ const queryBalanceCommand = new Command()
 	.description('Check your balance staked for Query requests')
 	.action(async () => {
 		try {
-			const client = getLogStoreClientFromOptions();
+			const { logStoreClient } = getClientsFromOptions();
 
 			const queryBalance = new Decimal(
-				(await client.getQueryBalance()).toString()
+				(await logStoreClient.getQueryBalance()).toString()
 			);
 
 			const availableStorage = queryBalance.div(readFeeMultiplier);

--- a/packages/cli/src/commands/query/query-stake.ts
+++ b/packages/cli/src/commands/query/query-stake.ts
@@ -1,8 +1,8 @@
 import { getRootOptions } from '@/commands/options';
 import { fastPriorityIfMainNet$ } from '@/utils/gasStation';
 import {
+	getClientsFromOptions,
 	getCredentialsFromOptions,
-	getLogStoreClientFromOptions,
 } from '@/utils/logstore-client';
 import { keepRetryingWithIncreasedGasPrice } from '@/utils/speedupTx';
 import {
@@ -37,7 +37,7 @@ const stakeCommand = new Command()
 	.option('-y, --assume-yes', 'Assume Yes to all queries and do not prompt')
 	.action(async (amt, cmdOptions) => {
 		const rootOptions = getRootOptions();
-		const logStoreClient = getLogStoreClientFromOptions();
+		const { logStoreClient } = getClientsFromOptions();
 
 		const amountToStakeInLSAN = cmdOptions.usd
 			? // todo: 1 LSAN = 1 by here

--- a/packages/cli/src/commands/store/list-streams.ts
+++ b/packages/cli/src/commands/store/list-streams.ts
@@ -1,4 +1,4 @@
-import { getLogStoreClientFromOptions } from '@/utils/logstore-client';
+import { getClientsFromOptions } from '@/utils/logstore-client';
 import { logger } from '@/utils/utils';
 import { Command } from '@commander-js/extra-typings';
 import chalk from 'chalk';
@@ -8,10 +8,10 @@ const listCommand = new Command()
 	.description('List your streams')
 	.action(async () => {
 		try {
-			const client = getLogStoreClientFromOptions();
+			const { streamrClient } = getClientsFromOptions();
 
-			const streams = client.searchStreams(
-				await client.getAddress(),
+			const streams = streamrClient.searchStreams(
+				await streamrClient.getAddress(),
 				undefined
 			);
 

--- a/packages/cli/src/commands/store/store-balance.ts
+++ b/packages/cli/src/commands/store/store-balance.ts
@@ -1,4 +1,4 @@
-import { getLogStoreClientFromOptions } from '@/utils/logstore-client';
+import { getClientsFromOptions } from '@/utils/logstore-client';
 import { bytesToMessage, logger } from '@/utils/utils';
 import { Command } from '@commander-js/extra-typings';
 import chalk from 'chalk';
@@ -9,10 +9,10 @@ const balanceCommand = new Command()
 	.description('Check your balance staked for Storage')
 	.action(async () => {
 		try {
-			const client = getLogStoreClientFromOptions();
+			const { logStoreClient } = getClientsFromOptions();
 
 			const storeBalance = new Decimal(
-				(await client.getStoreBalance()).toString()
+				(await logStoreClient.getStoreBalance()).toString()
 			);
 
 			const availableStorage = storeBalance;

--- a/packages/cli/src/commands/store/store-stake.ts
+++ b/packages/cli/src/commands/store/store-stake.ts
@@ -1,7 +1,7 @@
 import { fastPriorityIfMainNet$ } from '@/utils/gasStation';
 import {
+	getClientsFromOptions,
 	getCredentialsFromOptions,
-	getLogStoreClientFromOptions,
 } from '@/utils/logstore-client';
 import { keepRetryingWithIncreasedGasPrice } from '@/utils/speedupTx';
 import {
@@ -45,7 +45,7 @@ const stakeCommand = new Command()
 		});
 
 		try {
-			const logStoreClient = getLogStoreClientFromOptions();
+			const { logStoreClient } = getClientsFromOptions();
 			const amountToStakeInLSAN = cmdOptions.usd
 				? // todo this assumes the price is 1:1 (multiplier)
 				  await logStoreClient.convert({

--- a/packages/cli/src/commands/store/stream-balance.ts
+++ b/packages/cli/src/commands/store/stream-balance.ts
@@ -1,4 +1,4 @@
-import { getLogStoreClientFromOptions } from '@/utils/logstore-client';
+import { getClientsFromOptions } from '@/utils/logstore-client';
 import { bytesToMessage, logger } from '@/utils/utils';
 import { Command } from '@commander-js/extra-typings';
 import chalk from 'chalk';
@@ -15,11 +15,11 @@ const balanceCommand = new Command()
 		}
 
 		try {
-			const client = getLogStoreClientFromOptions();
-			const price = new Decimal((await client.getPrice()).toString());
+			const { logStoreClient } = getClientsFromOptions();
+			const price = new Decimal((await logStoreClient.getPrice()).toString());
 
 			const streamBalance = new Decimal(
-				(await client.getStreamBalance(streamId)).toString()
+				(await logStoreClient.getStreamBalance(streamId)).toString()
 			);
 
 			const availableStorage = streamBalance.div(price);

--- a/packages/cli/src/utils/logstore-client.ts
+++ b/packages/cli/src/utils/logstore-client.ts
@@ -1,8 +1,15 @@
 import { getRootOptions } from '@/commands/options';
 import { USE_TEST_CONFIG } from '@/env-config';
 import { logger } from '@/utils/utils';
-import { CONFIG_TEST, LogStoreClient } from '@logsn/client';
+import {
+	CONFIG_TEST as LOGSTORE_CONFIG_TEST,
+	LogStoreClient,
+} from '@logsn/client';
 import { ethers } from 'ethers';
+import {
+	CONFIG_TEST as STREAMR_CONFIG_TEST,
+	StreamrClient,
+} from 'streamr-client';
 
 function getCredentialsFrom(host: string, wallet: string) {
 	const provider = new ethers.providers.JsonRpcProvider(host);
@@ -11,11 +18,11 @@ function getCredentialsFrom(host: string, wallet: string) {
 }
 
 export function getCredentialsFromOptions() {
-	const { wallet, host } = getRootOptions();
+	const { wallet, host } = getRootOptions() as { wallet: string; host: string };
 	return getCredentialsFrom(host, wallet);
 }
 
-export function getLogstoreClientForCredentials({
+export function getClientsForCredentials({
 	host,
 	wallet,
 }: {
@@ -23,19 +30,21 @@ export function getLogstoreClientForCredentials({
 	wallet: string;
 }) {
 	const { provider } = getCredentialsFrom(host, wallet);
-	const { logLevel: _unused, ...additionalConfig } = USE_TEST_CONFIG
-		? CONFIG_TEST
-		: {};
+	const { logLevel: _unused, ...streamrConfig } = USE_TEST_CONFIG
+		? STREAMR_CONFIG_TEST
+		: ({} as never);
+	const logStoreConfig = USE_TEST_CONFIG ? LOGSTORE_CONFIG_TEST : {};
+
 	const logLevel = logger.settings.minLevel === 3 ? 'warn' : 'debug';
 	if (!('LOG_LEVEL' in process.env)) {
 		process.env.LOG_LEVEL = logLevel;
 	}
-	return new LogStoreClient({
-		...additionalConfig,
+	const streamrClient = new StreamrClient({
+		...streamrConfig,
 		logLevel: logLevel,
 		auth: { privateKey: wallet },
 		contracts: {
-			...additionalConfig?.contracts,
+			...streamrConfig?.contracts,
 			streamRegistryChainRPCs: {
 				rpcs: [provider.connection],
 				chainId: 8997,
@@ -43,9 +52,14 @@ export function getLogstoreClientForCredentials({
 			},
 		},
 	});
+	const logStoreClient = new LogStoreClient(streamrClient, {
+		logLevel,
+		...logStoreConfig,
+	});
+	return { logStoreClient, streamrClient };
 }
 
-export const getLogStoreClientFromOptions = () => {
-	const { wallet, host } = getRootOptions();
-	return getLogstoreClientForCredentials({ host, wallet });
+export const getClientsFromOptions = () => {
+	const { wallet, host } = getRootOptions() as { wallet: string; host: string };
+	return getClientsForCredentials({ host, wallet });
 };

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -1,4 +1,4 @@
-import { getLogstoreClientForCredentials } from '@/utils/logstore-client';
+import { getClientsForCredentials } from '@/utils/logstore-client';
 import { exec } from 'child_process';
 import path from 'path';
 
@@ -36,7 +36,7 @@ export const executeOnCli = async (
 		(resolve) => {
 			exec(execCommand, (error, stdout, stderr) => {
 				if (error) {
-					resolve({ stdout, stderr, code: error.code });
+					resolve({ stdout, stderr, code: Number( error.code ) });
 				} else {
 					resolve({ stdout, stderr, code: 0 });
 				}
@@ -46,7 +46,7 @@ export const executeOnCli = async (
 };
 
 export function getTestLogStoreClient(privateKey: string) {
-	return getLogstoreClientForCredentials({
+	return getClientsForCredentials({
 		host: 'http://localhost:8546',
 		wallet: privateKey,
 	});

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@logsn/client",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"description": "The Log Store Network Client",
 	"author": "Ryan Soury <ryan@usher.so>, Victor Shevtsov <victor.shevtsov@usher.so>",
 	"license": "Apache-2.0",

--- a/packages/client/src/Queries.ts
+++ b/packages/client/src/Queries.ts
@@ -4,7 +4,7 @@ import {
 	StreamPartIDUtils,
 } from '@streamr/protocol';
 import { Logger, randomString, toEthereumAddress } from '@streamr/utils';
-import { defer, EMPTY, map, partition, shareReplay } from 'rxjs';
+import { defer, EMPTY, filter, map, partition, shareReplay } from 'rxjs';
 import { inject, Lifecycle, scoped } from 'tsyringe';
 
 import {
@@ -294,6 +294,8 @@ export class Queries {
 			shareReplay({
 				refCount: true,
 			}),
+			map((line: string) => line.trim()), // remove ' ' and '\n' from the end of the line
+			filter(Boolean), // remove empty lines
 			map((line: string) => {
 				const msgObject = JSON.parse(line);
 				if (Array.isArray(msgObject)) {

--- a/packages/client/src/validationManager/ValidationManager.ts
+++ b/packages/client/src/validationManager/ValidationManager.ts
@@ -5,8 +5,9 @@ import {
 	type StreamMetadata,
 	StreamrClient,
 } from 'streamr-client';
-import { delay, inject, Lifecycle, scoped } from 'tsyringe';
+import { inject, Lifecycle, scoped } from 'tsyringe';
 
+import { StreamrClientInjectionToken } from '../streamr/StreamrClient';
 import { defaultAjv, getSchemaFromMetadata } from './getStreamSchema';
 import type { SchemaParams } from './types';
 
@@ -14,7 +15,7 @@ import type { SchemaParams } from './types';
 @scoped(Lifecycle.ContainerScoped)
 export class ValidationManager {
 	constructor(
-		@inject(delay(() => StreamrClient))
+		@inject(StreamrClientInjectionToken)
 		private streamrClient: StreamrClient
 	) {}
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@logsn/contracts",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"description": "The Log Store Network Solidity Contracts",
 	"author": "Ryan Soury <ryan@usher.so>",
 	"license": "GPL-3.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@logsn/protocol",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"description": "The Log Store Network Protocol",
 	"repository": {
 		"type": "git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@logsn/shared",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"description": "The Log Store Network Shared Library",
 	"repository": {
 		"type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       rxjs:
         specifier: 8.0.0-alpha.12
         version: 8.0.0-alpha.12
+      streamr-client:
+        specifier: ^8.5.5
+        version: 8.5.5(@ethersproject/hash@5.7.0)(typescript@4.9.5)
       tslog:
         specifier: ^4.8.2
         version: 4.8.2
@@ -896,7 +899,7 @@ importers:
     dependencies:
       '@graphprotocol/graph-cli':
         specifier: ^0.46.1
-        version: 0.46.1(@types/node@18.15.13)(typescript@5.3.3)
+        version: 0.46.1(@types/node@18.15.13)(node-fetch@2.7.0)(typescript@5.3.3)
       '@graphprotocol/graph-ts':
         specifier: ^0.29.3
         version: 0.29.3
@@ -3651,7 +3654,7 @@ packages:
     dev: false
     optional: true
 
-  /@graphprotocol/graph-cli@0.46.1(@types/node@18.15.13)(typescript@5.3.3):
+  /@graphprotocol/graph-cli@0.46.1(@types/node@18.15.13)(node-fetch@2.7.0)(typescript@5.3.3):
     resolution: {integrity: sha512-594BiH2m9gThP1xdvxguVzvVlOb1KzJyVdh2F4dV78NPfMRFY2fe1nakmadKcewc72VVLXNgfdBu/J4IPfo0eg==}
     engines: {node: '>=14'}
     hasBin: true
@@ -3671,7 +3674,7 @@ packages:
       gluegun: github.com/edgeandnode/gluegun/b34b9003d7bf556836da41b57ef36eb21570620a(debug@4.3.4)
       graphql: 15.5.0
       immutable: 4.2.1
-      ipfs-http-client: 55.0.0
+      ipfs-http-client: 55.0.0(node-fetch@2.7.0)
       jayson: 4.0.0
       js-yaml: 3.14.1
       prettier: 1.19.1
@@ -12611,6 +12614,7 @@ packages:
 
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    requiresBuild: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -12865,7 +12869,7 @@ packages:
       - supports-color
     dev: false
 
-  /ipfs-core-types@0.9.0:
+  /ipfs-core-types@0.9.0(node-fetch@2.7.0):
     resolution: {integrity: sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==}
     deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
     dependencies:
@@ -12877,7 +12881,7 @@ packages:
       - supports-color
     dev: false
 
-  /ipfs-core-utils@0.13.0:
+  /ipfs-core-utils@0.13.0(node-fetch@2.7.0):
     resolution: {integrity: sha512-HP5EafxU4/dLW3U13CFsgqVO5Ika8N4sRSIb/dTg16NjLOozMH31TXV0Grtu2ZWo1T10ahTzMvrfT5f4mhioXw==}
     deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
     dependencies:
@@ -12886,7 +12890,7 @@ packages:
       browser-readablestream-to-it: 1.0.3
       debug: 4.3.4(supports-color@8.1.1)
       err-code: 3.0.1
-      ipfs-core-types: 0.9.0
+      ipfs-core-types: 0.9.0(node-fetch@2.7.0)
       ipfs-unixfs: 6.0.9
       ipfs-utils: 9.0.14
       it-all: 1.0.6
@@ -12937,7 +12941,7 @@ packages:
       - supports-color
     dev: false
 
-  /ipfs-http-client@55.0.0:
+  /ipfs-http-client@55.0.0(node-fetch@2.7.0):
     resolution: {integrity: sha512-GpvEs7C7WL9M6fN/kZbjeh4Y8YN7rY8b18tVWZnKxRsVwM25cIFrRI8CwNt3Ugin9yShieI3i9sPyzYGMrLNnQ==}
     engines: {node: '>=14.0.0', npm: '>=3.0.0'}
     dependencies:
@@ -12948,8 +12952,8 @@ packages:
       any-signal: 2.1.2
       debug: 4.3.4(supports-color@8.1.1)
       err-code: 3.0.1
-      ipfs-core-types: 0.9.0
-      ipfs-core-utils: 0.13.0
+      ipfs-core-types: 0.9.0(node-fetch@2.7.0)
+      ipfs-core-utils: 0.13.0(node-fetch@2.7.0)
       ipfs-utils: 9.0.14
       it-first: 1.0.7
       it-last: 1.0.6


### PR DESCRIPTION
- a bug that only influenced ValidationManager from the client, that's why it became apparent now. Using StreamrClient on our client requires the new injection token, and the old one made it use the default configuration.
- another bug that for some reason was returning ' ' on empty queries, triggering a JSON.parse error. Solved by trimming before parse and filtering empty lines. Not entirely sure why this happens yet, and node responses might be the cause, but with this fix, every test is passing, making the client safe already.
- The CLI package was updated according to the client's refactor. The reason it was missed is probably the lack of a test script on its package.json and now it's included.
- bump packages to 0.0.11